### PR TITLE
Updated Version, SHA and dependencies for v0.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.6" %}
+{% set version = "0.4.2" %}
 
 package:
   name: s3transfer
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/s3transfer/s3transfer-{{ version }}.tar.gz
-  sha256: c5dadf598762899d8cfaecf68eba649cd25b0ce93b6c954b156aaa3eed160547
+  sha256: cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2
 
 build:
   noarch: python
@@ -18,6 +18,8 @@ requirements:
   host:
     - python >=3  # Avoid a py2k selector for the futures dependency
     - pip
+    - wheel
+    - setuptools
   run:
     - python >=3
     - botocore >=1.12.36,<2.0a.0
@@ -25,6 +27,10 @@ requirements:
 test:
   imports:
     - s3transfer
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/boto/s3transfer


### PR DESCRIPTION
Updated Version,SHA and dependency for v2.0.3 in Meta.yaml.

Category: anaconda
Version change: bump from 0.3.6 to 0.4.2
Changelog:https://github.com/boto/s3transfer/blob/develop/CHANGELOG.rst
Upstream Issues: https://github.com/boto/s3transfer/issues
Requirements https://github.com/boto/s3transfer/blob/develop/setup.py
License :https://github.com/boto/s3transfer/blob/develop/LICENSE.txt
The package builds correctly on concourse.