### PR TITLE
s3transfer 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 package:
   name: s3transfer
@@ -6,22 +6,22 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/s3transfer/s3transfer-{{ version }}.tar.gz
-  sha256: 50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c
+  sha256: 2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947
 
 build:
-  noarch: python
+  skip: true  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 
 requirements:
   host:
-    - python >=3.6  # Avoid a py2k selector for the futures dependency
+    - python
     - pip
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python
     - botocore >=1.12.36,<2.0a.0
 
 test:


### PR DESCRIPTION
s3transfer 0.6.0 -> boto3 1.24.2

Changelog: https://github.com/boto/s3transfer/blob/0.6.0/CHANGELOG.rst
Upstream Issues: https://github.com/boto/s3transfer/issues
Requirements: https://github.com/boto/s3transfer/blob/0.6.0/setup.py
License: https://github.com/boto/s3transfer/blob/0.6.0/LICENSE.txt

Actions:
1. Skip `py<37`
2. Remove `noarch: python`
3. Fix python in host and run