### PR TITLE
s3transfer 0.10.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
-{% set version = "0.7.0" %}
+{% set name = "s3transfer" %}
+{% set version = "0.10.1" %}
 
 package:
-  name: s3transfer
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/s3transfer/s3transfer-{{ version }}.tar.gz
-  sha256: fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 
 requirements:
@@ -22,7 +23,7 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.12.36,<2.0a.0
+    - botocore >=1.33.2,<2.0a.0
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:**

### Links

- [PKG-4618](https://anaconda.atlassian.net/browse/PKG-4618)
- release-notes-tagged: https://github.com/boto/s3transfer/releases/tag/0.10.1
- release-diff: https://github.com/boto/s3transfer/compare/0.7.0...0.10.1
- changelog: https://github.com/boto/s3transfer/blob/develop/CHANGELOG.rst
- license: https://github.com/boto/s3transfer/blob/develop/LICENSE.txt
- requirements-tagged:
  - https://github.com/boto/s3transfer/blob/0.10.1/setup.cfg
  - https://github.com/boto/s3transfer/blob/0.10.1/setup.py


### Explanation of changes:

- Update pinnings

### Notes:

- The build order of s3transfer 0.10.1: 
  - botocore 1.34.69:
    -> boto3 1.34.69
    -> aiobotocore 2.12.3 ->  s3fs 2024.3.1
    -> s3transfer 0.10.1


[PKG-4618]: https://anaconda.atlassian.net/browse/PKG-4618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ