### PR TITLE
s3transfer 0.14.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "s3transfer" %}
-{% set version = "0.11.2" %}
+{% set version = "0.14.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3b39185cb72f5acc77db1a58b6e25b977f28d20496b6e58d6813d75f464d632f
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125
 
 build:
-  skip: true  # [py<38]
   number: 0
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -40,7 +40,7 @@ test:
     - s3transfer
   commands:
     - pip check
-    - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})" tests
+    - pytest -v tests {{ ignore_tests }} -k "not ({{ tests_to_skip }})"
   requires:
     - pip
     - pytest


### PR DESCRIPTION
s3transfer 0.14.0 

**Destination channel:** Defaults

### Links

- [PKG-10254]
- dev_url:        https://github.com/boto/s3transfer/tree/0.14.0
- conda_forge:    https://github.com/conda-forge/s3transfer-feedstock
- pypi:           https://pypi.org/project/s3transfer/0.14.0
- pypi inspector: https://inspector.pypi.io/project/s3transfer/0.14.0

### Explanation of changes:

- new version number


[PKG-10254]: https://anaconda.atlassian.net/browse/PKG-10254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ