### PR TITLE
s3transfer 0.13.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "s3transfer" %}
-{% set version = "0.11.2" %}
+{% set version = "0.13.1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3b39185cb72f5acc77db1a58b6e25b977f28d20496b6e58d6813d75f464d632f
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf
 
 build:
-  skip: true  # [py<38]
   number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.36.0,<2.0a.0
+    - botocore >=1.37.4,<2.0a.0
 
 # Integration tests are required to validate real AWS services like S3 and SQS, which are not available in our environment.
 # Error example:
@@ -40,7 +40,7 @@ test:
     - s3transfer
   commands:
     - pip check
-    - pytest -v {{ ignore_tests }} -k "not ({{ tests_to_skip }})" tests
+    - pytest -v tests {{ ignore_tests }} -k "not ({{ tests_to_skip }})"
   requires:
     - pip
     - pytest
@@ -54,7 +54,7 @@ about:
   description: |
     S3transfer is a Python library for managing Amazon S3 transfers.
   dev_url: https://github.com/boto/s3transfer
-  doc_url: https://pypi.org/project/s3transfer/
+  doc_url: https://pypi.org/project/s3transfer
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
s3transfer 0.13.1 

**Destination channel:** Defaults

### Links

- [PKG-10836]
- dev_url:        https://github.com/boto/s3transfer/tree/0.13.1
- conda_forge:    https://github.com/conda-forge/s3transfer-feedstock
- pypi:           https://pypi.org/project/s3transfer/0.13.1
- pypi inspector: https://inspector.pypi.io/project/s3transfer/0.13.1

### Explanation of changes:

- new version number


[PKG-10836]: https://anaconda.atlassian.net/browse/PKG-10836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ