### PR TITLE
s3transfer 0.16.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "s3transfer" %}
-{% set version = "0.14.0" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125
+  sha256: 8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920
 
 build:
   number: 0
-  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.36.0,<2.0a.0
+    - botocore >=1.37.4,<2.0a.0
 
 # Integration tests are required to validate real AWS services like S3 and SQS, which are not available in our environment.
 # Error example:
@@ -54,7 +54,7 @@ about:
   description: |
     S3transfer is a Python library for managing Amazon S3 transfers.
   dev_url: https://github.com/boto/s3transfer
-  doc_url: https://pypi.org/project/s3transfer/
+  doc_url: https://pypi.org/project/s3transfer
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
s3transfer 0.16.0 

**Destination channel:** Defaults

### Links

- [PKG-11786]
- dev_url:        https://github.com/boto/s3transfer/tree/0.16.0
- conda_forge:    https://github.com/conda-forge/s3transfer-feedstock
- pypi:           https://pypi.org/project/s3transfer/0.16.0
- pypi inspector: https://inspector.pypi.io/project/s3transfer/0.16.0

### Explanation of changes:

- new version number


[PKG-11786]: https://anaconda.atlassian.net/browse/PKG-11786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ