### PR TITLE
s3transfer 0.18.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+channels:
+  - https://staging.continuum.io/pbp/fs/botocore-feedstock/pr74/9d26836

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/botocore-feedstock/pr74/9d26836

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "s3transfer" %}
-{% set version = "0.16.1" %}
+{% set version = "0.18.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524
+  sha256: 3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
 #   - botocore.exceptions.NoCredentialsError: Unable to locate credentials
 # Skipping integration tests:
 {% set ignore_tests = " --ignore=tests/integration/" %}
+# AssertionError: 'ChecksumMD5' not found in OrderedDict
+{% set tests_to_skip = "test_allowed_upload_params_are_valid" %}
 
 test:
   source_files:
@@ -37,7 +39,7 @@ test:
     - s3transfer
   commands:
     - pip check
-    - pytest -v tests {{ ignore_tests }}
+    - pytest -v tests {{ ignore_tests }} -k "not ({{ tests_to_skip }})"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,10 +29,6 @@ requirements:
 #   - botocore.exceptions.NoCredentialsError: Unable to locate credentials
 # Skipping integration tests:
 {% set ignore_tests = " --ignore=tests/integration/" %}
-# AttributeError: Can't pickle local object 'TestBaseManager.create_pid_manager.<locals>.PIDManager'
-{% set tests_to_skip = "test_can_provide_signal_handler_initializers_to_start" %}
-# AssertionError: 'ChecksumMD5' not found in OrderedDict
-{% set tests_to_skip = "test_allowed_upload_params_are_valid" %}
 
 test:
   source_files:
@@ -41,7 +37,7 @@ test:
     - s3transfer
   commands:
     - pip check
-    - pytest -v tests {{ ignore_tests }} -k "not ({{ tests_to_skip }})"
+    - pytest -v tests {{ ignore_tests }}
   requires:
     - pip
     - pytest


### PR DESCRIPTION
s3transfer 0.18.0 

**Destination channel:** Defaults

### Links

- [PKG-15288]
- dev_url:        https://github.com/boto/s3transfer
- conda_forge:    https://github.com/conda-forge/s3transfer-feedstock
- pypi:           https://pypi.org/project/s3transfer/0.18.0
- pypi inspector: https://inspector.pypi.io/project/s3transfer/0.18.0

### Explanation of changes:

- new version number


[PKG-15288]: https://anaconda.atlassian.net/browse/PKG-15288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ